### PR TITLE
Allow customizing interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ compatible with the `auth` argument of `os_*` Ansible modules.
 
 `os_flavors_cacert` is an optional path to a CA certificate bundle.
 
+`os_flavors_interface` is the endpoint URL type to fetch from the service
+catalog. Maybe be one of `public`, `admin`, or `internal`.
+
 `os_flavors` is a list of nova flavors to register. Each item should be a
 dict containing the items 'name', 'ram', 'disk', and 'vcpus'. Optionally, the
 dict may contain 'ephemeral' and 'swap' items. Optionally, the dict may also

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,10 @@ os_flavors_auth_type:
 # Authentication information.
 os_flavors_auth: {}
 
+# Endpoint URL type to fetch from the service catalog. Maybe be one of:
+# public, admin, or internal.
+os_flavors_interface:
+
 # List of nova flavors to register. Each item should be a dict containing the
 # following items:
 # - 'name': Name of the flavor.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,7 @@
     auth_type: "{{ os_flavors_auth_type }}"
     auth: "{{ os_flavors_auth }}"
     cacert: "{{ os_flavors_cacert | default(omit) }}"
+    interface: "{{ os_flavors_interface | default(omit, true) }}"
     name: "{{ item.name }}"
     ram: "{{ item.ram }}"
     vcpus: "{{ item.vcpus }}"


### PR DESCRIPTION
Most of the os_ ansible modules take an interface or endpoint_type parameter. This adds interface as a configurable parameter as it is most similar to OS_INTERFACE environment variable.