### PR TITLE
Switch from os-shade to os_openstacksdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - ln -s $(pwd) ../stackhpc.os-flavors
 
   # Install role dependencies
-  - ansible-galaxy install -p .. stackhpc.os-shade
+  - ansible-galaxy install -p .. stackhpc.os_openstacksdk
 
 script:
   # Run Ansible lint against the role

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ flavor object.
 Dependencies
 ------------
 
-This role depends on the `stackhpc.os-shade` role.
+This role depends on the `stackhpc.os_openstacksdk` role.
 
 Example Playbook
 ----------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,5 +17,5 @@ galaxy_info:
     - openstack
 
 dependencies:
-  - role: stackhpc.os-shade
-    os_shade_venv: "{{ os_flavors_venv }}"
+  - role: stackhpc.os_openstacksdk
+    os_openstacksdk_venv: "{{ os_flavors_venv }}"


### PR DESCRIPTION
Shade is no longer required by ansible modules.