### PR TITLE
Replacing deprecated module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ OpenStack Flavors
 =================
 
 This role can be used to register flavors in nova using the
-os\_nova\_flavor module.
+openstack.cloud.compute\_flavor module.
 
 Requirements
 ------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
     Role to register nova flavors in OpenStack
   company: StackHPC Ltd
   license: Apache2
-  min_ansible_version: 2.0
+  min_ansible_version: 2.9
   platforms:
     - name: EL
       versions:

--- a/tasks/flavors.yml
+++ b/tasks/flavors.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure nova flavors exist
-  os_nova_flavor:
+  openstack.cloud.compute_flavor:
     auth_type: "{{ os_flavors_auth_type }}"
     auth: "{{ os_flavors_auth }}"
     cacert: "{{ os_flavors_cacert | default(omit) }}"


### PR DESCRIPTION
 [`os_` prefixed module names are deprecated](https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_nova_flavor_module.html#id1).

Changing `os_nova_flavor` to [`openstack.cloud.compute_flavor`](https://docs.ansible.com/ansible/latest/collections/openstack/cloud/compute_flavor_module.html#ansible-collections-openstack-cloud-compute-flavor-module).